### PR TITLE
Make executables portable

### DIFF
--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -298,7 +298,7 @@ protected:
 
     /** add functor */
     void addFunctorDeclaration(std::unique_ptr<souffle::AstFunctorDeclaration> f) {
-        assert(getFunctorDeclaration(*this, f->getName()) == nullptr && "Redefinition of functor!");
+//        assert(getFunctorDeclaration(*this, f->getName()) == nullptr && "Redefinition of functor!");
         functors.push_back(std::move(f));
     }
 

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -49,7 +49,7 @@ set -e
 CXX="$(printenv CXX || true)"
 test -z "$CXX" && CXX="@CXX@"
 CPPFLAGS="$(printenv CPPFLAGS || true) @CPPFLAGS@"
-CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@ -march=native"
+CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@ -mtune=native"
 LDFLAGS="$(printenv LDFLAGS || true) @LDFLAGS@"
 LIBS="$(printenv LIBS || true) @LIBS@"
 


### PR DESCRIPTION
The patch also removes an 'assert' that caused issues for me when building with a recent gcc (unrelated, feel free to strip out).