### PR TITLE
Disable redundant AC_CONFIG_MACRO_DIRS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_CANONICAL_HOST   # host_cpu, host_vendor, and host_os
 AM_INIT_AUTOMAKE([foreign subdir-objects 1.9 tar-pax])
 AM_MAINTAINER_MODE
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_MACRO_DIRS([m4])
+#AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_MACRO_DIR([m4])
 
 dnl Do not set default CFLAGS and CXXFLAGS


### PR DESCRIPTION
This fixes builds with very recent libtool.